### PR TITLE
Modify delta time averaging to track integer division residual

### DIFF
--- a/frame_timer.cpp
+++ b/frame_timer.cpp
@@ -23,6 +23,7 @@ int64_t snap_frequencies[] = {time_60hz,        //60fps
 //I know you can and should use a ring buffer for this, but I didn't want to include dependencies in this sample code
 const int time_history_count = 4;
 int64_t time_averager[time_history_count] = {desired_frametime, desired_frametime, desired_frametime, desired_frametime};
+int64_t averager_residual = 0;
 
 //these are stored in my Application class and are not local variables in production code
 bool running = true;
@@ -58,11 +59,15 @@ while (running){
         time_averager[i] = time_averager[i+1];
     }
     time_averager[time_history_count-1] = delta_time;
-    delta_time = 0;
+    int64_t averager_sum = 0;
     for(int i = 0; i<time_history_count; i++){
-        delta_time += time_averager[i];
+        averager_sum += time_averager[i];
     }
-    delta_time /= time_history_count;
+    delta_time = averager_sum / time_history_count;
+
+    averager_residual += averager_sum % time_history_count;
+    delta_time += averager_residual / time_history_count;
+    averager_residual %= time_history_count;
 
   //add to the accumulator
     frame_accumulator += delta_time;


### PR DESCRIPTION
As discussed on twitter, time averaging drops some frames because of the integer division (see example below).
Feel free to edit the code / reuse the example.

```
	// NOTE:
	// * delta time averaging reduces the impact of lag spikes by delaying frame updates over the duration of the history
	// * averager_residual counts the number of (1 / time_history_count)-th of time unit in the accumulator
	// ex:
	// * -4,-3,-2 are perfect frames, taking 10ms
	// * -1 is a slow frame, taking 40 ms instead of 10 ms
	//
	//  i ; time : prev. hist  -> new hist    = sum -> total -> updt. ; acc. ; residual
	// ---------------------------------------------------------------------------
	//  0 ; 40ms : 10 10 10 10 -> 40 10 10 10 = 17  -> 17    -> 1     ; +7   ; +2/4
	//  1 ; 10ms : 40 10 10 10 -> 40 10 10 10 = 17  -> 24    -> 2     ; +4   ; +2/4
	// RESIDUAL INJECTION                                    -> 2     ; +5
	//  2 ; 10ms : 40 10 10 10 -> 40 10 10 10 = 17  -> 22    -> 2     ; +2   ; +2/4
	//  3 ; 10ms : 40 10 10 10 -> 40 10 10 10 = 17  -> 19    -> 1     ; +9   ; +2/4
	// RESIDUAL INJECTION                                    -> 2     ; +0
	//  4 ; 10ms : 40 10 10 10 -> 10 10 10 10 = 10  -> 10    -> 1     ; +0
	// ---------------------------------------------------------------------------
	//
	// 7 updates over 4 frames at ~2 per frame instead of 4 in the first frame and then 1 per frame for the next three frames
	// no residual injection gives 6 updates (+8 acc.) because of the +2 residual lost in the integer division
```